### PR TITLE
Dev/add elements method

### DIFF
--- a/docs/WORKING_WITH_NESTED_OBJECTS.md
+++ b/docs/WORKING_WITH_NESTED_OBJECTS.md
@@ -44,7 +44,7 @@ function fn(nestedComponent) {
 ### Adding nested components
 
 These are defined in `this.components`. Add new component objects in the constructor by calling the "set"
-method, `this.addNestedComponents`. This allows classes to inherit other elements from their base class when extending them.
+method, `this.addNestedComponents` or its alias of `this.addComponents`. This allows classes to inherit other elements from their base class when extending them.
 
 You can also extend the original elements
 with `this.components = { ...this.components, ... }` or use `Object.assign(this.components, { ... })` inside the class

--- a/docs/WORKING_WITH_NESTED_OBJECTS.md
+++ b/docs/WORKING_WITH_NESTED_OBJECTS.md
@@ -41,6 +41,19 @@ function fn(nestedComponent) {
 };
 ```
 
+### Adding nested components
+
+These are defined in `this.components`. Add new component objects in the constructor by calling the "set"
+method, `this.addNestedComponents`. This allows classes to inherit other elements from their base class when extending them.
+
+You can also extend the original elements
+with `this.components = { ...this.components, ... }` or use `Object.assign(this.components, { ... })` inside the class
+constructor,
+but this might produce warnings with using `this.components` before initialization.
+
+_Note: `this.components` defaults to being a protected method so they are only used in app action functions!
+If you want to access elements outside of app action, add `public components: NestedComponents` to your class._
+
 ### Example 1: A simple nested component object
 
 ```js
@@ -50,10 +63,11 @@ import AccountFormObject from "../components/account.form.object";
 class CreateAccountPage extends PageObject {
     contructor() {
         super({ path: `/create-account` });
-    }
-
-    AccountFormObject(fn) {
-        this.performWithin(this.container(), new AccountFormObject(), fn);
+        this.addNestedComponents = {
+            AccountFormObject(fn) {
+                this.performWithin(this.container(), new AccountFormObject(), fn);
+            },
+        };
     }
 }
 ```
@@ -91,17 +105,19 @@ class ToggleButton extends ComponentObject {
 }
 
 class SettingsObject extends ComponentObject {
+    public elements: Elements;
+    public components: NestedComponents;
+
     constructor() {
-        super(() => cy.get("div[id=\"settings\"]"));
-    }
-
-    public elements = {
-        displaySettingsForm: () => this.container().find(`form#mode-selectors`),
-
-    };
-
-    ToggleButton(fn, buttonText) {
-        this.performWithin(this.elements.displaySettingsForm(), new ToggleButton(buttonText), fn);
+        super(() => cy.get(`div[id="settings"]`));
+        this.addElements = {
+            displaySettingsForm: () => this.container().find(`form#mode-selectors`),
+        };
+        this.addNestedComponents = {
+            ToggleButton(fn, buttonText) {
+                this.performWithin(this.elements.displaySettingsForm(), new ToggleButton(buttonText), fn);
+            },
+        };
     }
 }
 ```
@@ -145,11 +161,10 @@ import AccountFormObject from "../components/account.form.object";
 class CreateAccountPage extends PageObject {
     constructor() {
         super({ path: `/create-account` });
+        this.addNestedComponents = {
+            AccountFormObject: (fn) => this.container().within(() => fn(new AccountFormObject())),
+        };
     }
-
-    public components = {
-        AccountFormObject: (fn) => this.container().within(() => fn(new AccountFormObject()))
-    };
 }
 ```
 
@@ -164,15 +179,13 @@ class ToggleButton extends ComponentObject {
 class SettingsObject extends ComponentObject {
     constructor() {
         super(() => cy.get(`div[id="settings"]`));
+        this.addElements = {
+            displaySettingsForm: () => this.container.find(`form#mode-selectors`),
+        };
+        this.addNestedComponents = {
+            ToggleButton: (fn) => this.elements.displaySettingsForm().within(() => fn(new ToggleButton(buttonText))),
+        };
     }
-
-    public elements = {
-        displaySettingsForm: () => this.container.find(`form#mode-selectors`),
-    };
-
-    public components = {
-        ToggleButton: (fn) => this.elements.displaySettingsForm().within(() => fn(new ToggleButton(buttonText))),
-    };
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -37,14 +37,11 @@
     "test:cypress:open:e2e": "cypress open --e2e --browser electron",
     "test:cypress:run:e2e": "cypress run --e2e  --browser electron"
   },
-  "dependencies": {
-    "@types/node": "^20.12.7",
-    "lodash": "^4.17.21"
-  },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@babel/plugin-transform-private-property-in-object": "^7.23.3",
     "@types/lodash": "^4.17.0",
+    "@types/node": "^20.12.7",
     "@typescript-eslint/eslint-plugin": "^6.18.1",
     "@typescript-eslint/parser": "^6.18.1",
     "cypress": "latest",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@babel/plugin-transform-private-property-in-object": "^7.23.3",
-    "@types/lodash": "^4.17.0",
     "@types/node": "^20.12.7",
     "@typescript-eslint/eslint-plugin": "^6.18.1",
     "@typescript-eslint/parser": "^6.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hammzj/cypress-page-object",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A set of template classes and guides to help with developing component and page objects in Cypress.",
   "author": "Zachary Hamm <zjhamm304+github@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "test",
     "test automation"
   ],
-  "main": "build/dist/index.js",
-  "types": "build/dist/index.d.ts",
+  "main": "index.ts",
   "files": [
-    "build/**/*",
+    "src/",
+    "index.ts",
     "LICENSE",
     "README.md"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hammzj/cypress-page-object",
-  "version": "2.1.0-hotfix-1",
+  "version": "2.1.1",
   "description": "A set of template classes and guides to help with developing component and page objects in Cypress.",
   "author": "Zachary Hamm <zjhamm304+github@gmail.com>",
   "license": "MIT",

--- a/src/component.object.ts
+++ b/src/component.object.ts
@@ -1,4 +1,3 @@
-import { gt, isEqual } from "lodash";
 import { BaseContainerFunction } from "./types";
 import ElementCollection from "./element.collection";
 
@@ -22,8 +21,9 @@ export default class ComponentObject extends ElementCollection {
     }
 
     assertExists(expectation: boolean = true): void {
-        if (isEqual(expectation, false)) {
-            if (gt(this._scopedIndex, 0)) {
+        if (!expectation) {
+            //@ts-ignore
+            if (this._scopedIndex < 0) {
                 /*
                 The scoped index is set above 0 (i.e., it is not the first-found instance).
                 Make sure at least a base container exists first,

--- a/src/component.object.ts
+++ b/src/component.object.ts
@@ -23,7 +23,7 @@ export default class ComponentObject extends ElementCollection {
     assertExists(expectation: boolean = true): void {
         if (!expectation) {
             //@ts-ignore
-            if (this._scopedIndex < 0) {
+            if (this._scopedIndex > 0) {
                 /*
                 The scoped index is set above 0 (i.e., it is not the first-found instance).
                 Make sure at least a base container exists first,

--- a/src/element.collection.ts
+++ b/src/element.collection.ts
@@ -1,5 +1,4 @@
 import { BaseContainerFunction, ComponentObjectFunction, Elements, NestedComponents, IMetadata } from "./types";
-import { isNil } from "lodash";
 
 /**
  * Base class for describing page objects and components, which have a collection of element selectors
@@ -8,9 +7,7 @@ export default abstract class ElementCollection {
     protected _baseContainerFn: BaseContainerFunction;
     protected _scopedIndex?: number;
     protected metadata: Partial<IMetadata>;
-    protected elements: Elements = {
-        container: () => this.container(),
-    };
+    protected elements: Elements;
     protected components?: NestedComponents = {};
 
     /**
@@ -22,6 +19,9 @@ export default abstract class ElementCollection {
     constructor(baseContainerFn: BaseContainerFunction = () => cy.root()) {
         this._baseContainerFn = baseContainerFn;
         this.metadata = {};
+        this.elements = {
+            container: () => this.container(),
+        };
     }
 
     /**
@@ -59,6 +59,28 @@ export default abstract class ElementCollection {
      */
     set index(i: number) {
         this.scopedIndex = i;
+    }
+
+    /**
+     * Adds new element selectors to the base group of existing elements
+     * WARNING: you will set `elements` as public in order to access them outside of app action functions!
+     * Just add `public elements: Elements` before your constructor.
+     * @param elements
+     * @private
+     */
+    protected set addElements(elements: Elements) {
+        this.elements = Object.assign(this.elements || {}, elements);
+    }
+
+    /**
+     * Adds new element selectors to the base group of existing elements
+     * WARNING: you will set `components` as public in order to access them outside of app action functions!
+     * Just add `public components: NestedComponentd` before your constructor.
+     * @param components
+     * @private
+     */
+    protected set addNestedComponents(components: NestedComponents) {
+        this.components = Object.assign(this.components || {}, components);
     }
 
     /**
@@ -104,7 +126,7 @@ export default abstract class ElementCollection {
      * when expecting multiple elements to be located.
      */
     container(): Cypress.Chainable<Cypress.JQueryWithSelector> {
-        return !isNil(this._scopedIndex) ?
+        return this._scopedIndex != null ?
                 this.getAllContainers().eq(this._scopedIndex)
             :   this.getAllContainers().first();
     }
@@ -158,6 +180,7 @@ export default abstract class ElementCollection {
      *   this.elements.form().within(() => fn(new RadioButtonObject(buttonText)));
      * }
      */
+    //@ts-ignore
     performWithin(
         baseElement: Cypress.Chainable<Cypress.JQueryWithSelector>,
         nestedComponent: ElementCollection,

--- a/src/element.collection.ts
+++ b/src/element.collection.ts
@@ -66,7 +66,7 @@ export default abstract class ElementCollection {
      * WARNING: you will set `elements` as public in order to access them outside of app action functions!
      * Just add `public elements: Elements` before your constructor.
      * @param elements
-     * @private
+     * @protected
      */
     protected set addElements(elements: Elements) {
         this.elements = Object.assign(this.elements || {}, elements);
@@ -77,10 +77,18 @@ export default abstract class ElementCollection {
      * WARNING: you will set `components` as public in order to access them outside of app action functions!
      * Just add `public components: NestedComponentd` before your constructor.
      * @param components
-     * @private
+     * @protected
      */
     protected set addNestedComponents(components: NestedComponents) {
         this.components = Object.assign(this.components || {}, components);
+    }
+
+    /**
+     *  @alias addNestedComponents
+     *  @protected
+     */
+    protected set addComponents(components: NestedComponents) {
+        this.addNestedComponents = components;
     }
 
     /**

--- a/src/page.object.ts
+++ b/src/page.object.ts
@@ -1,4 +1,3 @@
-import { isNil } from "lodash";
 import { IPageMetadata } from "./types";
 import ElementCollection from "./element.collection";
 
@@ -55,7 +54,7 @@ export default class PageObject extends ElementCollection {
      */
     #customPathUrl(...pathInputs: string[]) {
         const matches = this.metadata.path.match(PageObject.#PATH_REPLACEMENT_REGEX);
-        if (isNil(matches)) {
+        if (matches == null) {
             //console.error("No path variables exist found for URL path: " + this.metadata.path);
             return this.#urlObject().toString();
         }
@@ -63,7 +62,7 @@ export default class PageObject extends ElementCollection {
         let replacedPath = this.metadata.path.repeat(1);
         for (const pathVar of matches) {
             const sub = pathInputs.shift();
-            if (isNil(sub)) {
+            if (sub == null) {
                 throw new InsufficientPathVariablesError();
             }
             replacedPath = replacedPath.replace(pathVar, sub);
@@ -93,6 +92,7 @@ export default class PageObject extends ElementCollection {
         cy.url().should("eq", this.url(...pathInputs));
     }
 
+    //@ts-ignore
     performWithin(baseElement, nestedComponent, fn) {
         if (PageObject.prototype.isPrototypeOf(nestedComponent)) {
             throw new UnexpectedNestedPageObjectError();

--- a/tests/cypress/e2e/examples.cy.ts
+++ b/tests/cypress/e2e/examples.cy.ts
@@ -252,6 +252,69 @@ describe("Element collections", function () {
             });
 
             specify(
+                "nested component objects can be added using this.addNestedComponents or this.addComponents",
+                function () {
+                    class PricingHeaderObject extends ComponentObject {
+                        public elements: Elements;
+
+                        constructor() {
+                            super(() => cy.get(".MuiCardHeader-root"));
+                            this.addElements = {
+                                title: () => this.container().find(".MuiCardHeader-title"),
+                                subtitle: () => this.container().find(".MuiCardHeader-subheader"),
+                                starIcon: () => this.container().find(`svg[data-testid="StarBorderIcon"]`),
+                            };
+                        }
+                    }
+
+                    class PricingCardObject1 extends ComponentObject {
+                        public elements: Elements;
+                        public components: NestedComponents;
+
+                        constructor(title: string) {
+                            super(() => cy.contains(".MuiCardHeader-content", title).parents(".MuiCard-root"));
+                            this.addElements = {
+                                contentContainer: () => this.container().find(".MuiCardContent-root"),
+                                pricing: () => this.elements.contentContainer().find(".MuiBox-root"),
+                                listItem: (label: string) =>
+                                    this.elements.contentContainer().contains("ul > li", label),
+                                submitButton: () => this.container().find("button"),
+                            };
+                            this.addNestedComponents = {
+                                PricingHeaderObject: (fn: ComponentObjectFunction) =>
+                                    this.container().within(() => fn(new PricingHeaderObject())),
+                            };
+                        }
+                    }
+
+                    class PricingCardObject2 extends ComponentObject {
+                        public elements: Elements;
+                        public components: NestedComponents;
+
+                        constructor(title: string) {
+                            super(() => cy.contains(".MuiCardHeader-content", title).parents(".MuiCard-root"));
+                            this.addElements = {
+                                contentContainer: () => this.container().find(".MuiCardContent-root"),
+                                pricing: () => this.elements.contentContainer().find(".MuiBox-root"),
+                                listItem: (label: string) =>
+                                    this.elements.contentContainer().contains("ul > li", label),
+                                submitButton: () => this.container().find("button"),
+                            };
+                            this.addComponents = {
+                                PricingHeaderObject: (fn: ComponentObjectFunction) =>
+                                    this.container().within(() => fn(new PricingHeaderObject())),
+                            };
+                        }
+                    }
+
+                    const pco1 = new PricingCardObject1("Free");
+                    const pco2 = new PricingCardObject2("Free");
+                    expect(pco1.components.PricingHeaderObject).to.exist;
+                    expect(pco2.components.PricingHeaderObject).to.exist;
+                }
+            );
+
+            specify(
                 "[ALTERNATIVE]: component objects can nested other component objects using cy.within()",
                 function () {
                     class PricingHeaderObject extends ComponentObject {

--- a/tests/cypress/e2e/examples.cy.ts
+++ b/tests/cypress/e2e/examples.cy.ts
@@ -1,4 +1,4 @@
-import { PageObject, ComponentObject } from "../../../index";
+import { PageObject, ComponentObject, IPageMetadata } from "../../../index";
 import { ComponentObjectFunction, Elements, NestedComponents } from "../../../src";
 
 describe("Element collections", function () {
@@ -51,7 +51,7 @@ describe("Element collections", function () {
 
         specify("dynamic element selectors can be parameterized", function () {
             class ExamplePageObject extends PageObject {
-                public elements;
+                public elements: Elements;
 
                 constructor() {
                     super();
@@ -630,8 +630,8 @@ describe("Element collections", function () {
 
     describe("Page objects", function () {
         class AppBar extends ComponentObject {
-            public elements;
-            public components;
+            public elements: Elements;
+            public components: NestedComponents;
 
             constructor() {
                 super(() => cy.get(".MuiAppBar-root"));
@@ -852,7 +852,7 @@ describe("Element collections", function () {
 
             specify(`path variables can be set using path inputs`, function () {
                 class ExamplePageObject extends PageObject {
-                    constructor(metadata) {
+                    constructor(metadata: IPageMetadata) {
                         super(metadata);
                     }
                 }

--- a/tests/cypress/e2e/examples.cy.ts
+++ b/tests/cypress/e2e/examples.cy.ts
@@ -10,6 +10,8 @@ describe("Element collections", function () {
     context("Getters", function () {
         specify("element selectors in `this.elements`", function () {
             class ExamplePageObject extends PageObject {
+                public elements: Elements;
+
                 constructor() {
                     super();
                     //Just trying another way of doing this,
@@ -29,15 +31,16 @@ describe("Element collections", function () {
 
         specify("finding elements from a parent element selector", function () {
             class ExamplePageObject extends PageObject {
+                public elements: Elements;
+
                 constructor() {
                     super();
-                }
 
-                elements = {
-                    ...this.elements,
-                    appBar: () => cy.get(`.MuiAppBar-root`),
-                    loginButton: () => this.elements.appBar().contains(".MuiButtonBase-root", "Login"),
-                };
+                    this.addElements = {
+                        appBar: () => cy.get(`.MuiAppBar-root`),
+                        loginButton: () => this.elements.appBar().contains(".MuiButtonBase-root", "Login"),
+                    };
+                }
             }
 
             const examplePageObject = new ExamplePageObject();
@@ -48,18 +51,18 @@ describe("Element collections", function () {
 
         specify("dynamic element selectors can be parameterized", function () {
             class ExamplePageObject extends PageObject {
+                public elements;
+
                 constructor() {
                     super();
+                    this.addElements = {
+                        appBar: () => cy.get(`.MuiAppBar-root`),
+                        appLink: (label?: string) =>
+                            label ?
+                                this.elements.appBar().contains("a.MuiLink-root", label, { matchCase: true })
+                            :   this.elements.appBar().find("a.MuiLink-root"),
+                    };
                 }
-
-                elements = {
-                    ...this.elements,
-                    appBar: () => cy.get(`.MuiAppBar-root`),
-                    appLink: (label?: string) =>
-                        label ?
-                            this.elements.appBar().contains("a.MuiLink-root", label, { matchCase: true })
-                        :   this.elements.appBar().find("a.MuiLink-root"),
-                };
             }
 
             const examplePageObject = new ExamplePageObject();
@@ -72,18 +75,18 @@ describe("Element collections", function () {
 
         specify("[ALTERNATIVE]: filtering getters instead of using dynamic element selectors", function () {
             class ExamplePageObject extends PageObject {
+                public elements: Elements;
+
                 constructor() {
                     super();
+                    this.addElements = {
+                        appBar: () => cy.get(`.MuiAppBar-root`),
+                        appLink: (label?: string) =>
+                            label ?
+                                this.elements.appBar().contains("a.MuiLink-root", label, { matchCase: true })
+                            :   this.elements.appBar().find("a.MuiLink-root"),
+                    };
                 }
-
-                elements = {
-                    ...this.elements,
-                    appBar: () => cy.get(`.MuiAppBar-root`),
-                    appLink: (label?: string) =>
-                        label ?
-                            this.elements.appBar().contains("a.MuiLink-root", label, { matchCase: true })
-                        :   this.elements.appBar().find("a.MuiLink-root"),
-                };
             }
 
             const examplePageObject = new ExamplePageObject();
@@ -101,6 +104,8 @@ describe("Element collections", function () {
     describe("Component objects", function () {
         specify("component objects are located using a base container function", function () {
             class ProPricingCardObject extends ComponentObject {
+                public elements: Elements;
+
                 constructor() {
                     super(() => cy.contains(".MuiCard-root", "Pro"));
                 }
@@ -169,19 +174,19 @@ describe("Element collections", function () {
             specify("[ALTERNATE]: base container functions can be updated after creation", function () {
                 //This is useful when properties should be set on an object and saved.
                 class PricingCardObject extends ComponentObject {
+                    public elements: Elements;
+
                     constructor(title: string) {
                         super();
                         this.metadata.title = title;
                         this.updateBaseContainerFunction = () => {
                             return cy.contains(".MuiCardHeader-content", this.metadata.title).parents(".MuiCard-root");
                         };
+                        this.addElements = {
+                            header: () => this.container().find(".MuiCardHeader-root"),
+                            starIcon: () => this.elements.header().find('svg[data-testid="StarBorderIcon"]'),
+                        };
                     }
-
-                    elements = {
-                        ...this.elements,
-                        header: () => this.container().find(".MuiCardHeader-root"),
-                        starIcon: () => this.elements.header().find('svg[data-testid="StarBorderIcon"]'),
-                    };
                 }
 
                 cy.log(
@@ -195,36 +200,37 @@ describe("Element collections", function () {
 
             specify("component objects can nested other component objects using performWithin", function () {
                 class PricingHeaderObject extends ComponentObject {
+                    public elements: Elements;
+
                     constructor() {
                         super(() => cy.get(".MuiCardHeader-root"));
+                        this.addElements = {
+                            title: () => this.container().find(".MuiCardHeader-title"),
+                            subtitle: () => this.container().find(".MuiCardHeader-subheader"),
+                            starIcon: () => this.container().find('svg[data-testid="StarBorderIcon"]'),
+                        };
                     }
-
-                    elements = {
-                        ...this.elements,
-                        title: () => this.container().find(".MuiCardHeader-title"),
-                        subtitle: () => this.container().find(".MuiCardHeader-subheader"),
-                        starIcon: () => this.container().find('svg[data-testid="StarBorderIcon"]'),
-                    };
                 }
 
                 class PricingCardObject extends ComponentObject {
+                    public elements: Elements;
+                    public components: NestedComponents;
+
                     constructor(title: string) {
                         super(() => {
                             return cy.contains(".MuiCardHeader-content", title).parents(".MuiCard-root");
                         });
+                        this.addElements = {
+                            contentContainer: () => this.container().find(".MuiCardContent-root"),
+                            pricing: () => this.elements.contentContainer().find(".MuiBox-root"),
+                            listItem: (label: string) => this.elements.contentContainer().contains("ul > li", label),
+                            submitButton: () => this.container().find("button"),
+                        };
+                        this.addNestedComponents = {
+                            PricingHeaderObject: (fn: ComponentObjectFunction) =>
+                                this.performWithin(this.container(), new PricingHeaderObject(), fn),
+                        };
                     }
-
-                    elements = {
-                        ...this.elements,
-                        contentContainer: () => this.container().find(".MuiCardContent-root"),
-                        pricing: () => this.elements.contentContainer().find(".MuiBox-root"),
-                        listItem: (label: string) => this.elements.contentContainer().contains("ul > li", label),
-                        submitButton: () => this.container().find("button"),
-                    };
-                    components = {
-                        PricingHeaderObject: (fn: ComponentObjectFunction) =>
-                            this.performWithin(this.container(), new PricingHeaderObject(), fn),
-                    };
                 }
 
                 const proPricingCardObject = new PricingCardObject("Pro");
@@ -249,34 +255,37 @@ describe("Element collections", function () {
                 "[ALTERNATIVE]: component objects can nested other component objects using cy.within()",
                 function () {
                     class PricingHeaderObject extends ComponentObject {
+                        public elements: Elements;
+
                         constructor() {
                             super(() => cy.get(".MuiCardHeader-root"));
+                            this.addElements = {
+                                title: () => this.container().find(".MuiCardHeader-title"),
+                                subtitle: () => this.container().find(".MuiCardHeader-subheader"),
+                                starIcon: () => this.container().find(`svg[data-testid="StarBorderIcon"]`),
+                            };
                         }
-
-                        elements = {
-                            ...this.elements,
-                            title: () => this.container().find(".MuiCardHeader-title"),
-                            subtitle: () => this.container().find(".MuiCardHeader-subheader"),
-                            starIcon: () => this.container().find('svg[data-testid="StarBorderIcon"]'),
-                        };
                     }
 
                     class PricingCardObject extends ComponentObject {
+                        public elements: Elements;
+                        public components: NestedComponents;
+
                         constructor(title: string) {
                             super(() => cy.contains(".MuiCardHeader-content", title).parents(".MuiCard-root"));
-                        }
+                            this.addElements = {
+                                contentContainer: () => this.container().find(".MuiCardContent-root"),
+                                pricing: () => this.elements.contentContainer().find(".MuiBox-root"),
+                                listItem: (label: string) =>
+                                    this.elements.contentContainer().contains("ul > li", label),
+                                submitButton: () => this.container().find("button"),
+                            };
 
-                        elements = {
-                            ...this.elements,
-                            contentContainer: () => this.container().find(".MuiCardContent-root"),
-                            pricing: () => this.elements.contentContainer().find(".MuiBox-root"),
-                            listItem: (label: string) => this.elements.contentContainer().contains("ul > li", label),
-                            submitButton: () => this.container().find("button"),
-                        };
-                        components = {
-                            PricingHeaderObject: (fn: ComponentObjectFunction) =>
-                                this.container().within(() => fn(new PricingHeaderObject())),
-                        };
+                            this.addNestedComponents = {
+                                PricingHeaderObject: (fn: ComponentObjectFunction) =>
+                                    this.container().within(() => fn(new PricingHeaderObject())),
+                            };
+                        }
                     }
 
                     const proPricingCardObject = new PricingCardObject("Pro");
@@ -294,31 +303,32 @@ describe("Element collections", function () {
 
             specify("nested component objects can be parameterized", function () {
                 class LinkListObject extends ComponentObject {
+                    public elements: Elements;
+
                     constructor(title: string) {
                         super(() => cy.contains(".MuiTypography-h6", title).parent(".MuiGrid-item"));
+                        this.addElements = {
+                            link: (label: string) => this.container().contains("a", label, { matchCase: true }),
+                        };
                     }
-
-                    elements = {
-                        ...this.elements,
-                        link: (label: string) => this.container().contains("a", label, { matchCase: true }),
-                    };
                 }
 
                 class FooterObject extends ComponentObject {
+                    public elements: Elements;
+                    public components: NestedComponents;
+
                     constructor() {
                         super(() => cy.get(`footer`));
+                        this.addElements = {
+                            gridLayout: () => this.container().find(`.MuiGrid-container`),
+                            copyright: () => this.container().find(`p.MuiTypography-root`),
+                        };
+                        this.addNestedComponents = {
+                            LinkListObject: (fn: ComponentObjectFunction, title: string) => {
+                                return this.performWithin(this.elements.gridLayout(), new LinkListObject(title), fn);
+                            },
+                        };
                     }
-
-                    elements = {
-                        ...this.elements,
-                        gridLayout: () => this.container().find(`.MuiGrid-container`),
-                        copyright: () => this.container().find(`p.MuiTypography-root`),
-                    };
-                    components = {
-                        LinkListObject: (fn: ComponentObjectFunction, title: string) => {
-                            this.performWithin(this.elements.gridLayout(), new LinkListObject(title), fn);
-                        },
-                    };
                 }
 
                 const footerObject = new FooterObject();
@@ -341,6 +351,9 @@ describe("Element collections", function () {
 
         specify("different indices can change with which nested component is currently being interacted", function () {
             class LinkListObject extends ComponentObject {
+                public elements: Elements;
+                public components: NestedComponents;
+
                 //This time, the base container is going to be generically located
                 //So there is a chance for it to find more than one instance.
                 //Thus, setting the index is important
@@ -348,12 +361,11 @@ describe("Element collections", function () {
                     super(() => {
                         return cy.get(".MuiTypography-h6").parent(".MuiGrid-item");
                     });
+                    this.addElements = {
+                        title: () => this.container().find(".MuiTypography-h6"),
+                        link: () => this.container().find("ul > li"),
+                    };
                 }
-
-                elements = {
-                    title: () => this.container().find(".MuiTypography-h6"),
-                    link: () => this.container().find("ul > li"),
-                };
 
                 //app action to perform an assertion
                 assertLinksInOrder(...labels: string[]) {
@@ -366,18 +378,20 @@ describe("Element collections", function () {
             }
 
             class FooterObject extends ComponentObject {
+                public elements: Elements;
+                public components: NestedComponents;
+
                 constructor() {
                     super(() => cy.get(`footer`));
+                    this.addElements = {
+                        gridLayout: () => this.container().find(`.MuiGrid-container`),
+                    };
+
+                    this.addNestedComponents = {
+                        LinkListObject: (fn) =>
+                            this.performWithin(this.elements.gridLayout(), new LinkListObject(), fn),
+                    };
                 }
-
-                elements = {
-                    ...this.elements,
-                    gridLayout: () => this.container().find(`.MuiGrid-container`),
-                };
-
-                components = {
-                    LinkListObject: (fn) => this.performWithin(this.elements.gridLayout(), new LinkListObject(), fn),
-                };
             }
 
             const footerObject = new FooterObject();
@@ -420,17 +434,13 @@ describe("Element collections", function () {
                         super(() => {
                             return cy.contains(".MuiTypography-h6", title).parent(".MuiGrid-item");
                         });
+                        this.addElements = {
+                            link: () => this.container().find("ul > li"),
+                        };
                     }
-
-                    elements = {
-                        ...this.elements,
-                        link: () => this.container().find("ul > li"),
-                    };
 
                     //app action to perform an assertion
                     assertLinksInOrder(...labels: string[]) {
-                        cy.log("labels", labels);
-                        console.log("labels", labels);
                         this.elements.link().each(($link) => {
                             cy.wrap($link).should("have.text", labels.shift());
                         });
@@ -438,20 +448,21 @@ describe("Element collections", function () {
                 }
 
                 class FooterObject extends ComponentObject {
+                    public elements: Elements;
+                    public components: NestedComponents;
+
                     constructor() {
                         super(() => cy.get(`footer`));
+                        this.addElements = {
+                            gridLayout: () => this.container().find(`.MuiGrid-container`),
+                            copyright: () => this.container().find(`p.MuiTypography-root`),
+                        };
+                        this.addNestedComponents = {
+                            LinkListObject: (fn: ComponentObjectFunction, title: string) => {
+                                this.performWithin(this.elements.gridLayout(), new LinkListObject(title), fn);
+                            },
+                        };
                     }
-
-                    elements = {
-                        ...this.elements,
-                        gridLayout: () => this.container().find(`.MuiGrid-container`),
-                        copyright: () => this.container().find(`p.MuiTypography-root`),
-                    };
-                    components = {
-                        LinkListObject: (fn: ComponentObjectFunction, title: string) => {
-                            this.performWithin(this.elements.gridLayout(), new LinkListObject(title), fn);
-                        },
-                    };
 
                     //app action to perform a page action
                     visitCopyrightLink() {
@@ -529,65 +540,88 @@ describe("Element collections", function () {
                 });
             });
         });
+
+        specify(
+            "component objects can extend base classes and add new element selectors using this.addElements",
+            function () {
+                class PricingCardObject extends ComponentObject {
+                    public elements: Elements;
+
+                    constructor(title: string) {
+                        super(() => {
+                            return cy.contains(".MuiCardHeader-content", title).parents(".MuiCard-root");
+                        });
+                        this.addElements = {
+                            header: () => this.container().find(".MuiCardHeader-root"),
+                            starIcon: () => this.elements.header().find('svg[data-testid="StarBorderIcon"]'),
+                        };
+                    }
+                }
+
+                const freePricingCardObject = new PricingCardObject("Free");
+                freePricingCardObject.elements.container().should("exist").and("contain.text", "$0/mo");
+                freePricingCardObject.elements.starIcon().should("not.exist");
+            }
+        );
     });
 
     describe("Page objects", function () {
         class AppBar extends ComponentObject {
+            public elements;
+            public components;
+
             constructor() {
                 super(() => cy.get(".MuiAppBar-root"));
+                this.addElements = {
+                    link: (label: string) => this.container().contains("a.MuiLink-root", label, { matchCase: true }),
+                    loginButton: () => this.container().find(".MuiButtonBase-root"),
+                };
             }
-
-            elements = {
-                ...this.elements,
-                link: (label: string) => this.container().contains("a.MuiLink-root", label, { matchCase: true }),
-                loginButton: () => this.container().find(".MuiButtonBase-root"),
-            };
         }
 
         class PricingHeaderObject extends ComponentObject {
+            public elements: Elements;
+            public components: NestedComponents;
+
             constructor() {
                 super(() => cy.get(".MuiCardHeader-root"));
+                this.addElements = {
+                    title: () => this.container().find(".MuiCardHeader-title"),
+                    subtitle: () => this.container().find(".MuiCardHeader-subheader"),
+                    starIcon: () => this.container().find('svg[data-testid="StarBorderIcon"]'),
+                };
             }
-
-            elements = {
-                ...this.elements,
-                title: () => this.container().find(".MuiCardHeader-title"),
-                subtitle: () => this.container().find(".MuiCardHeader-subheader"),
-                starIcon: () => this.container().find('svg[data-testid="StarBorderIcon"]'),
-            };
         }
 
         class PricingCardObject extends ComponentObject {
+            public elements: Elements;
+            public components: NestedComponents;
+
             constructor(title: string) {
                 super(() => {
                     return cy.contains(".MuiCardHeader-content", title).parents(".MuiCard-root");
                 });
+                this.addElements = {
+                    contentContainer: () => this.container().find(".MuiCardContent-root"),
+                    pricing: () => this.container().find("button"),
+                    submitButton: () => this.elements.contentContainer().find(".MuiBox-root"),
+                    listItem: (label: string) => this.elements.contentContainer().contains("ul > li", label),
+                };
+                this.addNestedComponents = {
+                    PricingHeaderObject: (fn) => this.performWithin(this.container(), new PricingHeaderObject(), fn),
+                };
             }
-
-            elements = {
-                ...this.elements,
-                contentContainer: () => this.container().find(".MuiCardContent-root"),
-                pricing: () => this.container().find("button"),
-                submitButton: () => this.elements.contentContainer().find(".MuiBox-root"),
-                listItem: (label: string) => this.elements.contentContainer().contains("ul > li", label),
-            };
-
-            components = {
-                PricingHeaderObject: (fn) => this.performWithin(this.container(), new PricingHeaderObject(), fn),
-            };
         }
 
         class LinkListObject extends ComponentObject {
-            constructor(title) {
+            constructor(title: string) {
                 super(() => {
                     return cy.contains(".MuiTypography-h6", title).parent(".MuiGrid-item");
                 });
+                this.addElements = {
+                    link: () => this.container().find("ul > li"),
+                };
             }
-
-            elements = {
-                ...this.elements,
-                link: () => this.container().find("ul > li"),
-            };
 
             //app action to perform an assertion
             assertLinksInOrder(...labels: string[]) {
@@ -600,49 +634,49 @@ describe("Element collections", function () {
         }
 
         class FooterObject extends ComponentObject {
+            public components: NestedComponents;
+
             constructor() {
                 super(() => cy.get(`footer`));
+                this.addElements = {
+                    gridLayout: () => this.container().find(`.MuiGrid-container`),
+                    copyright: () => this.container().find(`p.MuiTypography-root`),
+                };
+                this.addNestedComponents = {
+                    LinkListObject: (fn, title: string) =>
+                        this.performWithin(this.elements.gridLayout(), new LinkListObject(title), fn),
+                };
             }
-
-            elements = {
-                ...this.elements,
-                gridLayout: () => this.container().find(`.MuiGrid-container`),
-                copyright: () => this.container().find(`p.MuiTypography-root`),
-            };
-            components = {
-                LinkListObject: (fn, title: string) =>
-                    this.performWithin(this.elements.gridLayout(), new LinkListObject(title), fn),
-            };
 
             //app action to perform a page action
             visitCopyrightLink() {
-                this.elements.copyright.find("a").click();
+                this.elements.copyright().find("a").click();
             }
         }
 
         class ExamplePageObject extends PageObject {
+            public elements: Elements;
+            public components: NestedComponents;
+
             constructor() {
                 super();
+                this.addElements = {
+                    main: () => this.container().find("main").first(),
+                    contentTitle: () => this.elements.main().find("h1").first(),
+                    contentDescription: () => this.elements.contentTitle().next(),
+                };
+                this.addNestedComponents = {
+                    AppBar: (fn) => {
+                        this.performWithin(this.container(), new AppBar(), fn);
+                    },
+                    PricingCardObject: (fn, title: string) => {
+                        this.performWithin(this.container(), new PricingCardObject(title), fn);
+                    },
+                    FooterObject: (fn) => {
+                        this.performWithin(this.container(), new FooterObject(), fn);
+                    },
+                };
             }
-
-            elements: Elements = {
-                ...this.elements,
-                main: () => this.container().find("main").first(),
-                contentTitle: () => this.elements.main().find("h1").first(),
-                contentDescription: () => this.elements.contentTitle().next(),
-            };
-
-            components: NestedComponents = {
-                AppBar: (fn) => {
-                    this.performWithin(this.container(), new AppBar(), fn);
-                },
-                PricingCardObject: (fn, title: string) => {
-                    this.performWithin(this.container(), new PricingCardObject(title), fn);
-                },
-                FooterObject: (fn) => {
-                    this.performWithin(this.container(), new FooterObject(), fn);
-                },
-            };
         }
 
         const examplePageObject = new ExamplePageObject();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,13 +22,12 @@
     "noImplicitThis": true,
     "noImplicitAny": false,
     "strictNullChecks": true,
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true
+    "allowSyntheticDefaultImports": true
   },
   "include": [
-    "src/**/*",
-    "index.ts"
+    "src/**/*"
   ],
+
   "types": [
     "typePatches"
   ]


### PR DESCRIPTION
# What
## `this.addElements` method
* allows adding element selectors  to avoid warnings of `Field 'elements' references itself` when defining elements using spread syntax

## `this.addNestedComponents` method
* allows adding nested components to avoid warnings of `Field 'components' references itself` when defining components using spread syntax
* also aliased as` this.addComponents`

## Remove `lodash`
It's not needed